### PR TITLE
Font-face declaration deprecation warning

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -2,14 +2,7 @@
 @import "o-colors/main";
 @import "o-hoverable/main";
 @import "scss/variables";
-@import "scss/deprecated/functions";
 @import "scss/mixins";
-
-@if ($o-ft-typography-is-silent == false) {
-	@each $usecase in $_o-ft-typography-fontface-usecase-mapping {
-		@include oFtTypographyIncludeFont(nth($usecase, 1));
-	}
-}
 
 @import "scss/titles";
 @import "scss/leads";
@@ -31,6 +24,12 @@
 $_o-ft-typography-deprecation-warnings: false;
 
 @import "scss/deprecated/index";
+
+@if ($o-ft-typography-is-silent == false) {
+	@each $usecase in $_o-ft-typography-fontface-usecase-mapping {
+		@include oFtTypographyIncludeFont(nth($usecase, 1));
+	}
+}
 
 // Switch deprecation warnings back on
 $_o-ft-typography-deprecation-warnings: true;

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -18,7 +18,6 @@
 	font-style: $style;
 }
 
-
 /// Offset text vertically
 /// compensates dead space by removing some margin bottom
 ///
@@ -60,25 +59,6 @@
 	2px 0 4px $color, -2px 0 4px $color,
 	0 2px 4px $color, 0 -2px 4px $color,
 	6px 0 1px $color;
-}
-
-
-
-/// Provides a typography focused interface for oFontsInclude()
-///
-/// @param {string} $type - one of $usecases
-/// @param {list} $usecases
-///
-/// @requires {mixin} oFontsInclude
-/// @requires {variable} _o-ft-typography-fontface-usecase-mapping
-@mixin oFtTypographyIncludeFont($type, $usecases: $_o-ft-typography-fontface-usecase-mapping) {
-	@warn 'oFtTypographyIncludeFont is being deprecated. In the next major version of o-ft-typography, you’ll need to include font-face declarations yourselves, using o-fonts or your own webfont loader.';
-
-	@each $usecase in $usecases {
-		@if ($type == nth($usecase, 1)) {
-			@include oFontsInclude(nth($usecase, 2), nth($usecase, 3));
-		}
-	}
 }
 
 /// Links styles

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -72,6 +72,8 @@
 /// @requires {mixin} oFontsInclude
 /// @requires {variable} _o-ft-typography-fontface-usecase-mapping
 @mixin oFtTypographyIncludeFont($type, $usecases: $_o-ft-typography-fontface-usecase-mapping) {
+	@warn 'oFtTypographyIncludeFont is being deprecated. In the next major version of o-ft-typography, you’ll need to include font-face declarations yourselves, using o-fonts or your own webfont loader.';
+
 	@each $usecase in $usecases {
 		@if ($type == nth($usecase, 1)) {
 			@include oFontsInclude(nth($usecase, 2), nth($usecase, 3));

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -9,20 +9,6 @@
 /// @type Boolean (true)
 $o-ft-typography-is-silent: true !default;
 
-/// Font face use cases
-/// @access private
-/// @type list
-$_o-ft-typography-fontface-usecase-mapping: (
-	metadata      BentonSans    normal,
-	lead          BentonSans    normal,
-	subheading    BentonSans    normal,
-	heading       BentonSans    bold,
-	label         BentonSans    normal,
-	label         BentonSans    bold,
-	body          BentonSans    normal,
-	body          BentonSans    bold
-);
-
 @include oColorsSetUseCase(o-ft-typography-heading-medium, border, pink-tint2);
 @include oColorsSetUseCase(o-ft-typography-heading-large, border, pink-tint4);
 @include oColorsSetUseCase(o-ft-typography-heading-large, text, black);

--- a/scss/deprecated/_functions.scss
+++ b/scss/deprecated/_functions.scss
@@ -1,10 +1,3 @@
-/// Typography classes prefix
-///
-/// @access private
-///
-/// @deprecated
-$_o-ft-typography-selector-prefix: o-ft-typography-;
-
 // Get list of placeholders, prefixed with module name
 @function oFtGetPrefixedPlaceholders($names) {
 	@if $_o-ft-typography-deprecation-warnings {

--- a/scss/deprecated/_index.scss
+++ b/scss/deprecated/_index.scss
@@ -1,3 +1,4 @@
+@import "variables";
 @import "functions";
 @import "mixins";
 @import "labels";

--- a/scss/deprecated/_mixins.scss
+++ b/scss/deprecated/_mixins.scss
@@ -44,3 +44,20 @@
 	}
 	@include _oFtlabelText;
 }
+
+
+/// Provides a typography focused interface for oFontsInclude()
+///
+/// @param {string} $type - one of $usecases
+/// @param {list} $usecases
+@mixin oFtTypographyIncludeFont($type, $usecases: $_o-ft-typography-fontface-usecase-mapping) {
+	@if $_o-ft-typography-deprecation-warnings {
+		@warn 'oFtTypographyIncludeFont is being deprecated. In the next major version of o-ft-typography, you’ll need to include font-face declarations yourselves, using o-fonts or your own webfont loader.';
+	}
+
+	@each $usecase in $usecases {
+		@if ($type == nth($usecase, 1)) {
+			@include oFontsInclude(nth($usecase, 2), nth($usecase, 3));
+		}
+	}
+}

--- a/scss/deprecated/_variables.scss
+++ b/scss/deprecated/_variables.scss
@@ -1,0 +1,21 @@
+/// Typography classes prefix
+///
+/// @access private
+///
+/// @deprecated
+$_o-ft-typography-selector-prefix: o-ft-typography-;
+
+/// Font face use cases
+/// @access private
+/// @deprecated
+/// @type list
+$_o-ft-typography-fontface-usecase-mapping: (
+	metadata      BentonSans    normal,
+	lead          BentonSans    normal,
+	subheading    BentonSans    normal,
+	heading       BentonSans    bold,
+	label         BentonSans    normal,
+	label         BentonSans    bold,
+	body          BentonSans    normal,
+	body          BentonSans    bold
+);


### PR DESCRIPTION
/ping @jamesnicholls @Thurst-ft In the next major version of o-ft-typography (which will be renamed o-typography), you’ll need to include font-face declarations yourselves, using o-fonts or your own webfont loader.