### PR TITLE
Prepare for @font face declarations removal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "0.10"
 before_install:
-  - npm install -g https://github.com/Financial-Times/origami-build-tools/tarball/master
+  - npm install -g https://github.com/Financial-Times/origami-build-tools/tarball/node-0.10
   - origami-build-tools install
 script:
   - origami-build-tools test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,3 @@ before_install:
   - origami-build-tools install
 script:
   - origami-build-tools test
-  - origami-build-tools verify

--- a/demos/badges.html
+++ b/demos/badges.html
@@ -4,9 +4,10 @@
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
 	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-ft-typography: badges demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:fontface,modernizr:textshadow,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-ft-typography:/demos/src/demo.scss" />

--- a/demos/body.html
+++ b/demos/body.html
@@ -4,9 +4,10 @@
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
 	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-ft-typography: body demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:fontface,modernizr:textshadow,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-ft-typography:/demos/src/demo.scss" />

--- a/demos/headings.html
+++ b/demos/headings.html
@@ -4,9 +4,10 @@
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
 	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-ft-typography: headings demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:fontface,modernizr:textshadow,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-ft-typography:/demos/src/demo.scss" />

--- a/demos/labels.html
+++ b/demos/labels.html
@@ -4,9 +4,10 @@
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
 	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-ft-typography: labels demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:fontface,modernizr:textshadow,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-ft-typography:/demos/src/demo.scss" />

--- a/demos/leads.html
+++ b/demos/leads.html
@@ -4,9 +4,10 @@
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
 	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-ft-typography: leads demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:fontface,modernizr:textshadow,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-ft-typography:/demos/src/demo.scss" />

--- a/demos/metadata.html
+++ b/demos/metadata.html
@@ -4,9 +4,10 @@
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
 	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-ft-typography: metadata demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:fontface,modernizr:textshadow,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-ft-typography:/demos/src/demo.scss" />

--- a/demos/titles.html
+++ b/demos/titles.html
@@ -4,9 +4,10 @@
 <!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
 <head>
 	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-ft-typography: titles demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:fontface,modernizr:textshadow,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-ft-typography:/demos/src/demo.scss" />

--- a/main.scss
+++ b/main.scss
@@ -25,7 +25,7 @@ $_o-ft-typography-deprecation-warnings: false;
 
 @import "scss/deprecated/index";
 
-@if ($o-ft-typography-is-silent == false) {
+@if ($o-ft-typography-is-silent == false and $o-ft-typography-output-font-face-declarations) {
 	@each $usecase in $_o-ft-typography-fontface-usecase-mapping {
 		@include oFtTypographyIncludeFont(nth($usecase, 1));
 	}

--- a/scss/_body_article.scss
+++ b/scss/_body_article.scss
@@ -8,19 +8,16 @@
 	margin: 0 0 9px;
 	border-bottom: 1px dotted oColorsGetColorFor(o-ft-typography-article-body-lead, border);
 	padding: 0 0 14px;
-	font-family: Georgia, 'Times New Roman', serif;
+	font-family: Georgia, serif;
 	font-weight: normal;
 	@include oFtTypographyFontSize(21, 27);
 	@include oColorsFor(o-ft-typography-article-body-lead body, text);
 }
 
 /// Default article text style
-///
-/// @requires {mixin} oFtTypographyFontSize
-/// @requires {mixin} oColorsFor
 @mixin oFtTypographyArticleBody {
 	@include oFtTypographyFontSize(16, 24);
-	font-family: Georgia, 'Times New Roman', serif;
+	font-family: Georgia, serif;
 	font-weight: normal;
 	@include oColorsFor(o-ft-typography-article-body body, text);
 }
@@ -32,10 +29,6 @@
 }
 
 /// Styles for <ul> and <ol> articles
-///
-/// @requires {mixin} oFtTypographyArticleBody
-/// @requires {mixin} oFtTypographyArticleBody
-/// @requires {mixin} oFtTypographyArticleBodyBlock
 @mixin oFtTypographyArticleBodyList {
 	list-style-position: outside;
 	padding-left: 20px;

--- a/scss/_leads.scss
+++ b/scss/_leads.scss
@@ -5,7 +5,7 @@
 
 /// Large leader
 @mixin oFtTypographyLeadLarge {
-	font-family: Georgia, 'Times New Roman', serif;
+	font-family: Georgia, serif;
 	font-weight: normal;
 	@include oFtTypographyFontSize(21, 26);
 	@include oColorsFor(o-ft-typography-lead-large o-ft-typography-lead body, text);
@@ -14,7 +14,7 @@
 
 /// Medium leader
 @mixin oFtTypographyLeadMedium {
-	font-family: Georgia, 'Times New Roman', serif;
+	font-family: Georgia, serif;
 	font-weight: normal;
 	@include oFtTypographyFontSize(17, 21);
 	@include oColorsFor(o-ft-typography-lead-medium o-ft-typography-lead body, text);

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -11,7 +11,6 @@
 /// @param {string} $style [normal]
 ///
 /// @access private
-/// @requires oFontsGetFontFamilyWithFallbacks
 @mixin _oFtTypographyFont($family, $weight: normal, $style: normal) {
 	font-family: oFontsGetFontFamilyWithFallbacks($family);
 	font-weight: $weight;

--- a/scss/_titles.scss
+++ b/scss/_titles.scss
@@ -5,7 +5,7 @@
 
 /// Large title
 @mixin oFtTypographyTitleLarge {
-	font-family: Georgia, 'Times New Roman', serif;
+	font-family: Georgia, serif;
 	font-weight: normal;
 	@include oFtTypographyFontSize(30, 36, -5);
 	@include oColorsFor(o-ft-typography-title-large o-ft-typography-title title, text);
@@ -14,7 +14,7 @@
 
 /// Medium title
 @mixin oFtTypographyTitleMedium {
-	font-family: Georgia, 'Times New Roman', serif;
+	font-family: Georgia, serif;
 	font-weight: normal;
 	@include oFtTypographyFontSize(21, 26);
 	@include oColorsFor(o-ft-typography-title-medium o-ft-typography-title title, text);
@@ -23,7 +23,7 @@
 
 /// Small title
 @mixin oFtTypographyTitleSmall {
-	font-family: Georgia, 'Times New Roman', serif;
+	font-family: Georgia, serif;
 	font-weight: bold;
 	@include oFtTypographyFontSize(15, 17);
 	@include oColorsFor(o-ft-typography-title-small o-ft-typography-title title, text);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -9,6 +9,11 @@
 /// @type Bool
 $o-ft-typography-is-silent: true !default;
 
+/// Output @font-face declarations?
+/// nb: @font-face declarations will be removed in the next major version
+/// @type Bool
+$o-ft-typography-output-font-face-declarations: true !default;
+
 @include oColorsSetUseCase(o-ft-typography-heading-medium, border, pink-tint2);
 @include oColorsSetUseCase(o-ft-typography-heading-large, border, pink-tint4);
 @include oColorsSetUseCase(o-ft-typography-heading-large, text, black);

--- a/scss/deprecated/_mixins.scss
+++ b/scss/deprecated/_mixins.scss
@@ -18,11 +18,7 @@
 /// @deprecated
 ///
 /// @param {String} $names - Sass list of placeholder/class names in the format "name1 name2" but without the quotes. Will automatically by prefixed with module name.
-/// @param {list} $cssSelectors (()) - CSS selectors which should also receive the same styles. Does not get auto-prefixed, so must be exactly as you want output on the CSS.
-///
-/// @requires {function} oFtGetPrefixedPlaceholders
-/// @requires {function} oFtGetPrefixedClasses
-/// @requires {variable} $o-ft-typography-is-silent
+/// @param {list} $cssSelectors [()] - CSS selectors which should also receive the same styles. Does not get auto-prefixed, so must be exactly as you want output on the CSS.
 @mixin oFtTypographySelectors($names, $cssSelectors: ()) {
 	@if $_o-ft-typography-deprecation-warnings {
 		@warn 'oFtTypographySelectors is deprecated and will be removed in the next major release';
@@ -31,7 +27,10 @@
 	$selectors: append($selectors, oFtGetPrefixedPlaceholders($names));
 	@if ($o-ft-typography-is-silent == false) {
 		$selectors: append($selectors, oFtGetPrefixedClasses($names));
-		$selectors: append($selectors, unquote($cssSelectors), comma);
+		@if type-of($cssSelectors) == string {
+			$cssSelectors: unquote($cssSelectors);
+		}
+		$selectors: append($selectors, $cssSelectors, comma);
 	}
 	#{$selectors} {
 		@content;
@@ -51,13 +50,15 @@
 /// @param {string} $type - one of $usecases
 /// @param {list} $usecases
 @mixin oFtTypographyIncludeFont($type, $usecases: $_o-ft-typography-fontface-usecase-mapping) {
-	@if $_o-ft-typography-deprecation-warnings {
-		@warn 'oFtTypographyIncludeFont is being deprecated. In the next major version of o-ft-typography, you’ll need to include font-face declarations yourselves, using o-fonts or your own webfont loader.';
-	}
+	@if $o-ft-typography-output-font-face-declarations {
+		@if $_o-ft-typography-deprecation-warnings {
+			@warn 'oFtTypographyIncludeFont is being deprecated. In the next major version of o-ft-typography, you’ll need to include font-face declarations yourselves, using o-fonts or your own webfont loader.';
+		}
 
-	@each $usecase in $usecases {
-		@if ($type == nth($usecase, 1)) {
-			@include oFontsInclude(nth($usecase, 2), nth($usecase, 3));
+		@each $usecase in $usecases {
+			@if ($type == nth($usecase, 1)) {
+				@include oFontsInclude(nth($usecase, 2), nth($usecase, 3));
+			}
 		}
 	}
 }

--- a/scss/deprecated/_wrapped.scss
+++ b/scss/deprecated/_wrapped.scss
@@ -1,3 +1,4 @@
+// scss-lint:disable DeclarationOrder
 @mixin oFtTypographyCommonWrappedBodyStyles() {
 	@if $_o-ft-typography-deprecation-warnings {
 		@warn 'oFtTypographyCommonWrappedBodyStyles is deprecated and will be removed in the next major release';
@@ -60,7 +61,6 @@
 }
 
 @include oFtTypographySelectors(body-wrapper) {
-
 	h2 {
 		@include oFtTypographyExtend(heading5);
 	}
@@ -83,6 +83,5 @@
 		@include oFtTypographyExtend(body__list);
 	}
 
-	@include oFtTypographyCommonWrappedBodyStyles();
-
+	@include oFtTypographyCommonWrappedBodyStyles;
 }


### PR DESCRIPTION
- Fix linting errors with latest version of scss-lint
- Fix a syntax error in Sass 3.4 (`unquote()` won't accept an empty list as an argument anymore)
- Remove Times New Roman from front families
- Add a parameter to avoid outputting any `@font-face` declarations /cc @Thurst-ft @jamesnicholls 